### PR TITLE
Ignore VS2015 IDE autocompletion database files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ ipch
 *.sdf
 *.user
 *.VC.db
+*.VC.opendb

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ ipch
 *.opensdf
 *.sdf
 *.user
+*.VC.db


### PR DESCRIPTION
VS2015 U1 (the IDE, not the compiler) switches the IntelliSense database storage from SQL Compact (.sdf/.opensdf) to SQLite.

These commits add both new files to the .gitignore file.