### PR TITLE
Generate debug symbols for Normal VS builds

### DIFF
--- a/solution_normal.props
+++ b/solution_normal.props
@@ -17,6 +17,7 @@
       <AdditionalDependencies>freetype2311.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup />


### PR DESCRIPTION
Enabling the /DEBUG switch for the linker on Windows does not have any adverse effects, the required switch is already passed to the compiler, and post-mortem debugging would be desired even for production compiles.

As modern Windows toolchains generate debug information in a separate file (*.pdb), this shouldn't be an issue even for released builds like those in the media repository.