### PR TITLE
Enable VT100 escape code processing on Windows

### DIFF
--- a/engine/main.cpp
+++ b/engine/main.cpp
@@ -93,6 +93,22 @@ void app_fatal()
 
 int main (int argc, const char **argv)
 {
+#ifdef WIN32
+	{
+		// set the console to accept escape sequences (Win10+)
+		HANDLE console = GetStdHandle(STD_OUTPUT_HANDLE);
+
+		if (console != INVALID_HANDLE_VALUE)
+		{
+			DWORD consoleMode = 0;
+			GetConsoleMode(console, &consoleMode);
+
+			consoleMode |= 4; // ENABLE_VIRTUAL_TERMINAL_PROCESSING; but that isn't available in our current SDK target
+
+			SetConsoleMode(console, consoleMode);
+		}
+	}
+#endif
 
     int exit_code = EXIT_SUCCESS;
 


### PR DESCRIPTION
Windows 10 (from release build 10586 up) support ANSI escape sequences in the modern (V2) console host implementation. This commit enables this for whatever console might be bound to the standard output stream, as would be useful for debugging from the VS IDE.

The lack of error checking for getting/setting modes should have no adverse effects, though inherited consoles from parent processes may get their behavior changed undesirably if these happen to be incompatible with the new mode; potentially a check for [other attached processes](https://blogs.msdn.microsoft.com/oldnewthing/20160125-00/?p=92922) could be added.